### PR TITLE
fix: agregar columna password_hash y credenciales de prueba

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,17 @@ GitLab Flow adaptado:
 
 ### 🔑 Credenciales de Prueba
 
-#### Usuario Administrador (producción / Docker)
+Todos los usuarios de prueba usan la misma contraseña: **`test123`**
 
-| Campo    | Valor                          |
-| -------- | ------------------------------ |
-| Email    | `admin@makerbox.cl`            |
-| Password | `admin123`                     |
+| Rol          | Email        | Password | Descripción        |
+| ------------ | ------------ | -------- | ------------------ |
+| Solicitante  | `sol@uc.cl`  | test123  | Usuario SOL        |
+| Estudiante   | `est@uc.cl`  | test123  | Usuario EST        |
+| Ayudante     | `ayu@uc.cl`  | test123  | Usuario AYU        |
+| Profesor     | `pro@uc.cl`  | test123  | Usuario PRO        |
+| Admin        | `adm@uc.cl`  | test123  | Usuario ADM        |
 
-Este usuario se crea automáticamente mediante el seed script `db/seeds/02-admin-user.sh`. Requiere que la migración `db/migrations/02-add-password-hash.sh` haya sido ejecutada primero.
+> **Nota:** Estos usuarios se crean automáticamente al levantar los contenedores con `docker compose up --build`. No requieren ejecutar migraciones manuales.
 
 #### Endpoints de Autenticación
 
@@ -120,11 +123,11 @@ Este usuario se crea automáticamente mediante el seed script `db/seeds/02-admin
 
 ```bash
 # Obtener token JWT
-curl -X POST http://localhost/api/auth/token \
+curl -X POST http://localhost:8000/auth/token \
   -H "Content-Type: application/json" \
-  -d '{"email": "admin@makerbox.cl", "password": "admin123"}'
+  -d '{"email": "sol@uc.cl", "password": "test123"}'
 
 # Usar token para obtener perfil
-curl http://localhost/api/auth/me \
+curl http://localhost:8000/auth/me \
   -H "Authorization: Bearer <token>"
 ```

--- a/db/init/01-init.sql
+++ b/db/init/01-init.sql
@@ -35,6 +35,7 @@ CREATE TABLE usuario (
     email VARCHAR(255) UNIQUE,
     rol VARCHAR(50),
     estado BOOLEAN DEFAULT true,
+    password_hash VARCHAR(255) NOT NULL DEFAULT '',
     creado_en TIMESTAMP,
     actualizado_en TIMESTAMP,
     CONSTRAINT pk_usuario PRIMARY KEY (id_usuario)

--- a/db/init/04-seed-test-users.sql
+++ b/db/init/04-seed-test-users.sql
@@ -3,9 +3,66 @@
 -- Todos usan contraseña: test123
 -- ============================================================
 
-INSERT INTO usuario (id_usuario, nombre, apellido, correo, email, rol, estado, password_hash, creado_en, actualizado_en) VALUES
-('11111111-1111-1111-1111-111111111111', 'Solicitante', 'Test', 'sol@uc.cl', 'sol@uc.cl', 'SOL', true, '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG', NOW(), NOW()),
-('22222222-2222-2222-2222-222222222222', 'Estudiante', 'Test', 'est@uc.cl', 'est@uc.cl', 'EST', true, '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG', NOW(), NOW()),
-('33333333-3333-3333-3333-333333333333', 'Ayudante', 'Test', 'ayu@uc.cl', 'ayu@uc.cl', 'AYU', true, '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG', NOW(), NOW()),
-('44444444-4444-4444-4444-444444444444', 'Profesor', 'Test', 'pro@uc.cl', 'pro@uc.cl', 'PRO', true, '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG', NOW(), NOW()),
-('55555555-5555-5555-5555-555555555555', 'Admin', 'Test', 'adm@uc.cl', 'adm@uc.cl', 'ADM', true, '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG', NOW(), NOW());
+INSERT INTO usuario (
+    id_usuario, nombre, apellido, correo, email, rol, estado, password_hash, creado_en, actualizado_en
+) VALUES
+(
+    '11111111-1111-1111-1111-111111111111',
+    'Solicitante',
+    'Test',
+    'sol@uc.cl',
+    'sol@uc.cl',
+    'SOL',
+    true,
+    '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG',
+    NOW(),
+    NOW()
+),
+(
+    '22222222-2222-2222-2222-222222222222',
+    'Estudiante',
+    'Test',
+    'est@uc.cl',
+    'est@uc.cl',
+    'EST',
+    true,
+    '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG',
+    NOW(),
+    NOW()
+),
+(
+    '33333333-3333-3333-3333-333333333333',
+    'Ayudante',
+    'Test',
+    'ayu@uc.cl',
+    'ayu@uc.cl',
+    'AYU',
+    true,
+    '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG',
+    NOW(),
+    NOW()
+),
+(
+    '44444444-4444-4444-4444-444444444444',
+    'Profesor',
+    'Test',
+    'pro@uc.cl',
+    'pro@uc.cl',
+    'PRO',
+    true,
+    '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG',
+    NOW(),
+    NOW()
+),
+(
+    '55555555-5555-5555-5555-555555555555',
+    'Admin',
+    'Test',
+    'adm@uc.cl',
+    'adm@uc.cl',
+    'ADM',
+    true,
+    '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG',
+    NOW(),
+    NOW()
+);

--- a/db/init/04-seed-test-users.sql
+++ b/db/init/04-seed-test-users.sql
@@ -1,10 +1,11 @@
 -- ============================================================
 -- Seed: usuarios de prueba determinísticos por rol
+-- Todos usan contraseña: test123
 -- ============================================================
 
-INSERT INTO usuario (id_usuario, nombre, apellido, correo, email, rol, estado, creado_en, actualizado_en) VALUES
-('11111111-1111-1111-1111-111111111111', 'Solicitante', 'Test', 'sol@uc.cl', 'sol@uc.cl', 'SOL', true, NOW(), NOW()),
-('22222222-2222-2222-2222-222222222222', 'Estudiante', 'Test', 'est@uc.cl', 'est@uc.cl', 'EST', true, NOW(), NOW()),
-('33333333-3333-3333-3333-333333333333', 'Ayudante', 'Test', 'ayu@uc.cl', 'ayu@uc.cl', 'AYU', true, NOW(), NOW()),
-('44444444-4444-4444-4444-444444444444', 'Profesor', 'Test', 'pro@uc.cl', 'pro@uc.cl', 'PRO', true, NOW(), NOW()),
-('55555555-5555-5555-5555-555555555555', 'Admin', 'Test', 'adm@uc.cl', 'adm@uc.cl', 'ADM', true, NOW(), NOW());
+INSERT INTO usuario (id_usuario, nombre, apellido, correo, email, rol, estado, password_hash, creado_en, actualizado_en) VALUES
+('11111111-1111-1111-1111-111111111111', 'Solicitante', 'Test', 'sol@uc.cl', 'sol@uc.cl', 'SOL', true, '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG', NOW(), NOW()),
+('22222222-2222-2222-2222-222222222222', 'Estudiante', 'Test', 'est@uc.cl', 'est@uc.cl', 'EST', true, '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG', NOW(), NOW()),
+('33333333-3333-3333-3333-333333333333', 'Ayudante', 'Test', 'ayu@uc.cl', 'ayu@uc.cl', 'AYU', true, '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG', NOW(), NOW()),
+('44444444-4444-4444-4444-444444444444', 'Profesor', 'Test', 'pro@uc.cl', 'pro@uc.cl', 'PRO', true, '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG', NOW(), NOW()),
+('55555555-5555-5555-5555-555555555555', 'Admin', 'Test', 'adm@uc.cl', 'adm@uc.cl', 'ADM', true, '$2b$12$LgQ.frDQCIygXqt8Bn3lFOu/QPA448z/Nl3faCbxRobRuTGa8dwDG', NOW(), NOW());


### PR DESCRIPTION
- Agrega password_hash a la tabla usuario en el schema init
- Incluye bcrypt hash en los usuarios de prueba del seed
- Actualiza README con credenciales funcionales de todos los roles